### PR TITLE
Fix miter issues

### DIFF
--- a/xfl2svg/shape/edge.py
+++ b/xfl2svg/shape/edge.py
@@ -208,6 +208,7 @@ def point_list_to_path_format(point_list: list) -> str:
     """Convert a point list into the SVG path format."""
     point_iter = iter(point_list)
     path = ["M", next(point_iter)]
+    first_point = path[1]
     last_command = "M"
 
     try:
@@ -223,10 +224,13 @@ def point_list_to_path_format(point_list: list) -> str:
             if command == "Q":
                 # Append control point and destination point
                 path.append(point[0])
-                path.append(next(point_iter))
+                point = next(point_iter)
+                path.append(point)
             else:
                 path.append(point)
     except StopIteration:
+        if point == first_point:
+            path.append("Z")
         return " ".join(path)
 
 

--- a/xfl2svg/shape/style.py
+++ b/xfl2svg/shape/style.py
@@ -91,7 +91,7 @@ def parse_stroke_style(style):
     update(
         attrib,
         ("stroke", "stroke-opacity", "stroke-miterlimit"),
-        (*parse_solid_color(fill), style.get("miterLimit")),
+        (*parse_solid_color(fill), style.get("miterLimit", "5")),
     )
 
     return attrib

--- a/xfl2svg/shape/style.py
+++ b/xfl2svg/shape/style.py
@@ -88,10 +88,14 @@ def parse_stroke_style(style):
         warnings.warn(f"Unknown stroke fill: {xml_str(fill)}")
         return attrib
 
-    update(
-        attrib,
-        ("stroke", "stroke-opacity", "stroke-miterlimit"),
-        (*parse_solid_color(fill), style.get("miterLimit", "5")),
-    )
+    update(attrib, ("stroke", "stroke-opacity"), parse_solid_color(fill))
+    if attrib["stroke-linejoin"] == "miter":
+        # If the XFL does not specify a miterLimit, Animate's SVG exporter will
+        # set stroke-miterlimit to 3. This seems to match what Flash does [*].
+        # But, in some cases, a limit of 5 better matches Animate's PNG render.
+        # So, that's what we use.
+        #
+        # [*]: https://github.com/ruffle-rs/ruffle/blob/d3becd9/core/src/avm1/globals/movie_clip.rs#L283-L290
+        attrib["stroke-miterlimit"] = style.get("miterLimit", "5")
 
     return attrib

--- a/xfl2svg/util.py
+++ b/xfl2svg/util.py
@@ -15,6 +15,10 @@ def check_known_attrib(element, known):
     """Ensure that an XML element doesn't have unknown attributes."""
     if not set(element.keys()) <= known:
         unknown = set(element.keys()) - known
+        if "}" not in element.tag:
+            warnings.warn(f"Unknown <{element.tag}> {element.attrib}\n")
+            return
+
         tag = element.tag.split("}")[1]
         warnings.warn(
             f"Unknown <{tag}> attributes: {element.attrib}\n"
@@ -42,4 +46,13 @@ def get_matrix(element):
             matrix.get("d") or "1",
             matrix.get("tx") or "0",
             matrix.get("ty") or "0",
+        ]
+    else:
+        return [
+            "1",
+            "0",
+            "0",
+            "1",
+            "0",
+            "0",
         ]

--- a/xfl2svg/util.py
+++ b/xfl2svg/util.py
@@ -15,11 +15,8 @@ def check_known_attrib(element, known):
     """Ensure that an XML element doesn't have unknown attributes."""
     if not set(element.keys()) <= known:
         unknown = set(element.keys()) - known
-        if "}" not in element.tag:
-            warnings.warn(f"Unknown <{element.tag}> {element.attrib}\n")
-            return
-
-        tag = element.tag.split("}")[1]
+        # Remove namespace, if present
+        tag = re.match(r"(\{[^}]+\})?(.*)", element.tag)[2]
         warnings.warn(
             f"Unknown <{tag}> attributes: {element.attrib}\n"
             f"  Known keys:   {known}\n"
@@ -46,13 +43,4 @@ def get_matrix(element):
             matrix.get("d") or "1",
             matrix.get("tx") or "0",
             matrix.get("ty") or "0",
-        ]
-    else:
-        return [
-            "1",
-            "0",
-            "0",
-            "1",
-            "0",
-            "0",
         ]


### PR DESCRIPTION
The "edge cases for missing attributes" commit adds a warning & pass-through error handling when there are missing attributes.
The "fix default miter limit & closed path" commit fixes the discrepancy between default miter limits in XFL and SVG and marks closed paths so they get miter'd properly.