### PR TITLE
use type hint classes for backwards compatibility

### DIFF
--- a/xfl2svg/shape/edge.py
+++ b/xfl2svg/shape/edge.py
@@ -40,7 +40,7 @@ in how everything works, read on.
 
 from collections import defaultdict
 import re
-from typing import Iterator
+from typing import Dict, Iterator, List, Tuple
 import xml.etree.ElementTree as ET
 
 
@@ -305,7 +305,7 @@ def point_list_to_path_format(point_list: list) -> str:
 #                      +----->+
 
 
-def point_lists_to_shapes(point_lists: list[tuple[list, str]]) -> dict[str, list[list]]:
+def point_lists_to_shapes(point_lists: List[Tuple[list, str]]) -> Dict[str, List[list]]:
     """Join point lists and fill style IDs into shapes.
 
     Args:
@@ -368,9 +368,9 @@ def point_lists_to_shapes(point_lists: list[tuple[list, str]]) -> dict[str, list
 
 def xfl_edge_to_svg_path(
     edges_element: ET.Element,
-    fill_styles: dict[str, dict],
-    stroke_styles: dict[str, dict],
-) -> tuple[list[ET.Element], list[ET.Element]]:
+    fill_styles: Dict[str, dict],
+    stroke_styles: Dict[str, dict],
+) -> Tuple[List[ET.Element], List[ET.Element]]:
     """Convert the XFL <edges> element into SVG <path> elements.
 
     Args:

--- a/xfl2svg/shape/gradient.py
+++ b/xfl2svg/shape/gradient.py
@@ -4,6 +4,7 @@
 
 
 from dataclasses import dataclass
+from typing import Tuple
 import xml.etree.ElementTree as ET
 
 from xfl2svg.util import check_known_attrib, get_matrix
@@ -11,9 +12,9 @@ from xfl2svg.util import check_known_attrib, get_matrix
 
 @dataclass(frozen=True)
 class LinearGradient:
-    start: tuple[float, float]
-    end: tuple[float, float]
-    stops: tuple[tuple[float, str, str], ...]
+    start: Tuple[float, float]
+    end: Tuple[float, float]
+    stops: Tuple[Tuple[float, str, str], ...]
     spread_method: str
 
     @classmethod


### PR DESCRIPTION
When specializing type for type hints, the type[...] notation causes
problems for older version of Python. Using the type hint classes from
the typing module fixes this.

list -> List
tuple -> Tuple
dict -> Dict