### PR TITLE
only check indent attr when required

### DIFF
--- a/xfl2svg/__main__.py
+++ b/xfl2svg/__main__.py
@@ -111,7 +111,7 @@ def main():
     main_imports()
 
     # Check if ET.indent is available
-    if not hasattr(ET, "indent"):
+    if args.indent and not hasattr(ET, "indent"):
         die("--indent requires Python 3.9+")
 
     # Create XFL reader and SVG renderer


### PR DESCRIPTION
Only check for ET.indent when --indent is specified. This is needed for older versions of python.