### PR TITLE
move default matrix case to gradient.py

### DIFF
--- a/xfl2svg/shape/gradient.py
+++ b/xfl2svg/shape/gradient.py
@@ -9,6 +9,8 @@ import xml.etree.ElementTree as ET
 
 from xfl2svg.util import check_known_attrib, get_matrix
 
+IDENTITY_MATRIX = ["1", "0", "0", "1", "0", "0"]
+
 
 @dataclass(frozen=True)
 class LinearGradient:
@@ -39,7 +41,7 @@ class LinearGradient:
         coordinates, which are more precise).
         """
 
-        a, b, _, _, tx, ty = map(float, get_matrix(element))
+        a, b, _, _, tx, ty = map(float, get_matrix(element) or IDENTITY_MATRIX)
         start = (a * -16384/20 + tx, b * -16384/20 + ty)  # fmt: skip
         end   = (a *  16384/20 + tx, b *  16384/20 + ty)  # fmt: skip
 

--- a/xfl2svg/util.py
+++ b/xfl2svg/util.py
@@ -4,7 +4,6 @@ import re
 import warnings
 
 CHARACTER_ENTITY_REFERENCE = re.compile(r"&#(\d+)")
-IDENTITY_MATRIX = ["1", "0", "0", "1", "0", "0"]
 
 
 def unescape_entities(s):
@@ -45,5 +44,3 @@ def get_matrix(element):
             matrix.get("tx") or "0",
             matrix.get("ty") or "0",
         ]
-
-    return IDENTITY_MATRIX


### PR DESCRIPTION
Returning an explicit identity matrix in get_matrix() results in
unnecessary information being added to the SVG. This function is only
used in two places: gradient.py and svg_renderer.py. svg_renderer.py
already handles the default case. This change updates graidnet.py to
handle it as well.