### PR TITLE
handle RadialGradient fill style

### DIFF
--- a/xfl2svg/shape/gradient.py
+++ b/xfl2svg/shape/gradient.py
@@ -4,7 +4,7 @@
 
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import List, Tuple
 import xml.etree.ElementTree as ET
 
 from xfl2svg.util import check_known_attrib, get_matrix
@@ -70,6 +70,71 @@ class LinearGradient:
                 "y1": str(self.start[1]),
                 "x2": str(self.end[0]),
                 "y2": str(self.end[1]),
+                "spreadMethod": self.spread_method,
+            },
+        )
+        for offset, color, alpha in self.stops:
+            attrib = {"offset": f"{offset}%", "stop-color": color}
+            if alpha is not None:
+                attrib["stop-opacity"] = alpha
+            ET.SubElement(element, "stop", attrib)
+        return element
+
+    @property
+    def id(self):
+        """Unique ID used to dedup SVG elements in <defs>."""
+        return f"Gradient_{hash(self) & 0xFFFF_FFFF:08x}"
+
+
+@dataclass(frozen=True)
+class RadialGradient:
+    matrix: Tuple[float, ...]
+    radius: float
+    stops: Tuple[Tuple[float, str, str], ...]
+    spread_method: str
+
+    @classmethod
+    def from_xfl(cls, element):
+        a, b, c, d, tx, ty = map(float, get_matrix(element))
+        radius = a**2 + b**2 + c**2
+
+        norm = (a**2 + b**2) ** 0.5
+        svg_a = a / norm
+        svg_b = b / norm
+        svg_c = c / norm
+        svg_d = d / norm
+        svg_matrix = (svg_a, svg_b, svg_c, svg_d, tx, ty)
+
+        stops = []
+        for entry in element.iterfind("{*}GradientEntry"):
+            check_known_attrib(entry, {"ratio", "color", "alpha"})
+            stops.append(
+                (
+                    float(entry.get("ratio")) * 100,
+                    entry.get("color", "#000000"),
+                    entry.get("alpha"),
+                )
+            )
+
+        check_known_attrib(element, {"spreadMethod"})
+        spread_method = element.get("spreadMethod", "pad")
+
+        return cls(svg_matrix, radius, tuple(stops), spread_method)
+
+    def to_svg(self):
+        """Create an SVG <linearGradient> element from a LinearGradient."""
+        matrix = map(str, self.matrix)
+        element = ET.Element(
+            "radialGradient",
+            {
+                "id": self.id,
+                "gradientUnits": "userSpaceOnUse",
+                "cx": "0",
+                "cy": "0",
+                "r": str(self.radius),
+                "fx": "0",
+                "fy": "0",
+                "gradientTransform": f"matrix({','.join(matrix)})",
                 "spreadMethod": self.spread_method,
             },
         )

--- a/xfl2svg/shape/style.py
+++ b/xfl2svg/shape/style.py
@@ -3,7 +3,7 @@
 import xml.etree.ElementTree as ET
 import warnings
 
-from xfl2svg.shape.gradient import LinearGradient
+from xfl2svg.shape.gradient import LinearGradient, RadialGradient
 from xfl2svg.util import check_known_attrib
 
 
@@ -47,7 +47,9 @@ def parse_fill_style(style):
         extra_defs[gradient.id] = gradient.to_svg()
     elif style.tag.endswith("RadialGradient"):
         # TODO: Support RadialGradient
-        warnings.warn("RadialGradient is not supported yet")
+        gradient = RadialGradient.from_xfl(style)
+        attrib["fill"] = f"url(#{gradient.id})"
+        extra_defs[gradient.id] = gradient.to_svg()
     else:
         warnings.warn(f"Unknown fill style: {xml_str(style)}")
 


### PR DESCRIPTION
This was done by messing around with XFL files and having Animate
generate the corresponding SVGs. The radius and matrix element functions
were found just by guessing and checking. They seem to work as expected
on several scenes that previously were rendered incorrectly.