### PR TITLE
add support for radial gradients

### DIFF
--- a/xfl2svg/shape/gradient.py
+++ b/xfl2svg/shape/gradient.py
@@ -4,7 +4,7 @@
 
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import List, Tuple
 import xml.etree.ElementTree as ET
 
 from xfl2svg.util import check_known_attrib, get_matrix
@@ -70,6 +70,75 @@ class LinearGradient:
                 "y1": str(self.start[1]),
                 "x2": str(self.end[0]),
                 "y2": str(self.end[1]),
+                "spreadMethod": self.spread_method,
+            },
+        )
+        for offset, color, alpha in self.stops:
+            attrib = {"offset": f"{offset}%", "stop-color": color}
+            if alpha is not None:
+                attrib["stop-opacity"] = alpha
+            ET.SubElement(element, "stop", attrib)
+        return element
+
+    @property
+    def id(self):
+        """Unique ID used to dedup SVG elements in <defs>."""
+        return f"Gradient_{hash(self) & 0xFFFF_FFFF:08x}"
+
+
+@dataclass(frozen=True)
+class RadialGradient:
+    matrix: Tuple[float, ...]
+    radius: float
+    focal_point: float
+    stops: Tuple[Tuple[float, str, str], ...]
+    spread_method: str
+
+    @classmethod
+    def from_xfl(cls, element, radius):
+        a, b, c, d, tx, ty = map(float, get_matrix(element))
+        focal_point = float(element.get("focalPointRatio", 0)) * radius
+
+        norm = (a**2 + b**2) ** 0.5
+        if norm == 0:
+            svg_matrix = ("NaN", "NaN", "NaN", "NaN")
+        else:
+            svg_a = a / norm
+            svg_b = b / norm
+            svg_c = c / norm
+            svg_d = d / norm
+            svg_matrix = (svg_a, svg_b, svg_c, svg_d, tx, ty)
+
+        stops = []
+        for entry in element.iterfind("{*}GradientEntry"):
+            check_known_attrib(entry, {"ratio", "color", "alpha"})
+            stops.append(
+                (
+                    float(entry.get("ratio")) * 100,
+                    entry.get("color", "#000000"),
+                    entry.get("alpha"),
+                )
+            )
+
+        check_known_attrib(element, {"spreadMethod", "focalPointRatio"})
+        spread_method = element.get("spreadMethod", "pad")
+
+        return cls(svg_matrix, radius, focal_point, tuple(stops), spread_method)
+
+    def to_svg(self):
+        """Create an SVG <linearGradient> element from a LinearGradient."""
+        matrix = map(str, self.matrix)
+        element = ET.Element(
+            "radialGradient",
+            {
+                "id": self.id,
+                "gradientUnits": "userSpaceOnUse",
+                "cx": "0",
+                "cy": "0",
+                "r": str(self.radius),
+                "fx": str(self.focal_point),
+                "fy": "0",
+                "gradientTransform": f"matrix({','.join(matrix)})",
                 "spreadMethod": self.spread_method,
             },
         )

--- a/xfl2svg/shape/shape.py
+++ b/xfl2svg/shape/shape.py
@@ -1,10 +1,61 @@
 """Convert the XFL <DOMShape> element to SVG <path> elements."""
 
-import xml.etree.ElementTree as ET
 import warnings
+import xml.etree.ElementTree as ET
+from numpy import expand_dims
 
-from xfl2svg.shape.edge import xfl_edge_to_svg_path
+from xfl2svg.shape.edge import xfl_edge_to_shapes
 from xfl2svg.shape.style import parse_fill_style, parse_stroke_style
+from xfl2svg.util import merge_bounding_boxes
+
+
+# This function converts point lists into the SVG path format.
+def point_list_to_path_format(point_list: list) -> str:
+    """Convert a point list into the SVG path format."""
+    point_iter = iter(point_list)
+    path = ["M", next(point_iter)]
+    points = []
+    last_command = "M"
+
+    try:
+        while True:
+            point = next(point_iter)
+            command = "Q" if isinstance(point, tuple) else "L"
+            # SVG lets us omit the command letter if we use the same command
+            # multiple times in a row.
+            if command != last_command:
+                path.append(command)
+                last_command = command
+
+            if command == "Q":
+                # Append control point and destination point
+                path.append(point[0])
+                path.append(next(point_iter))
+            else:
+                path.append(point)
+    except StopIteration:
+        if point_list[0] == point_list[-1]:
+            # Animate adds a "closepath" (Z) command to every filled shape and
+            # closed stroke. For shapes, it makes no difference, but for closed
+            # strokes, it turns two overlapping line caps into a bevel, miter,
+            # or round join, which does make a difference.
+            # TODO: It is likely that closed strokes can be broken into
+            # segments and spread across multiple Edge elements, which would
+            # require a function like point_lists_to_shapes(), but for strokes.
+            # For now, though, adding "Z" to any stroke that is already closed
+            # seems good enough.
+            # path.append("Z")
+            pass
+        return " ".join(path)
+
+
+def expanding_bounding_box(box, width):
+    return (
+        box[0] - width / 2,
+        box[1] - width / 2,
+        box[2] + width / 2,
+        box[3] + width / 2,
+    )
 
 
 def xfl_domshape_to_svg(domshape, mask=False):
@@ -24,25 +75,50 @@ def xfl_domshape_to_svg(domshape, mask=False):
 
     fill_styles = {}
     for style in domshape.iterfind(".//{*}FillStyle"):
-        index = style.get("index")
-        if mask:
-            # Set the fill to white so that the mask is fully transparent.
-            fill_styles[index] = {"fill": "#FFFFFF", "stroke": "none"}
-        else:
-            fill_style, fill_extra = parse_fill_style(style[0])
-            fill_styles[index] = fill_style
-            extra_defs.update(fill_extra)
+        fill_styles[style.get("index")] = style
 
     stroke_styles = {}
     for style in domshape.iterfind(".//{*}StrokeStyle"):
+        stroke_styles[style.get("index")] = style
+
+    shapes, strokes = xfl_edge_to_shapes(
+        domshape.find("{*}edges"), fill_styles, stroke_styles
+    )
+    bounding_box = None
+
+    filled_paths = []
+    for fill_id, fill_data in shapes.items():
+        point_lists, curr_bounding_box = fill_data
+        style = fill_styles[fill_id]
+        if mask:
+            # Set the fill to white so that the mask is fully transparent.
+            fill_style = {"fill": "#FFFFFF", "stroke": "none"}
+        else:
+            fill_style, fill_extra = parse_fill_style(style[0], curr_bounding_box)
+            extra_defs.update(fill_extra)
+
+        path = ET.Element("path", fill_style)
+        path.set("d", " ".join(point_list_to_path_format(pl) for pl in point_lists))
+        filled_paths.append(path)
+        bounding_box = merge_bounding_boxes(bounding_box, curr_bounding_box)
+
+    stroked_paths = []
+    for stroke_id, stroke_data in strokes.items():
+        point_lists, curr_bounding_box = stroke_data
+        style = stroke_styles[stroke_id]
         # TODO: Figure out how strokes are supposed to behave in masks
         if mask:
             warnings.warn("Strokes in masks are not supported")
-        stroke_styles[style.get("index")] = parse_stroke_style(style[0])
+        stroke_style, stroke_extra = parse_stroke_style(style[0], curr_bounding_box)
+        extra_defs.update(stroke_extra)
 
-    filled_paths, stroked_paths = xfl_edge_to_svg_path(
-        domshape.find("{*}edges"), fill_styles, stroke_styles
-    )
+        stroke_width = float(stroke_style.get("stroke-width", 1))
+        curr_bounding_box = expanding_bounding_box(curr_bounding_box, stroke_width)
+
+        stroke = ET.Element("path", stroke_style)
+        stroke.set("d", " ".join(point_list_to_path_format(pl) for pl in point_lists))
+        stroked_paths.append(stroke)
+        bounding_box = merge_bounding_boxes(bounding_box, curr_bounding_box)
 
     fill_g = None
     if filled_paths:
@@ -56,4 +132,4 @@ def xfl_domshape_to_svg(domshape, mask=False):
         stroke_g = ET.Element("g")
         stroke_g.extend(stroked_paths)
 
-    return fill_g, stroke_g, extra_defs
+    return fill_g, stroke_g, extra_defs, bounding_box

--- a/xfl2svg/shape/style.py
+++ b/xfl2svg/shape/style.py
@@ -3,7 +3,7 @@
 import xml.etree.ElementTree as ET
 import warnings
 
-from xfl2svg.shape.gradient import LinearGradient
+from xfl2svg.shape.gradient import LinearGradient, RadialGradient
 from xfl2svg.util import check_known_attrib
 
 
@@ -29,7 +29,13 @@ def parse_solid_color(style):
     return style.get("color", "#000000"), style.get("alpha")
 
 
-def parse_fill_style(style):
+def get_radius(bounding_box):
+    width = bounding_box[2] - bounding_box[0]
+    height = bounding_box[3] - bounding_box[1]
+    return (width**2 + height**2) ** 0.5 / 2
+
+
+def parse_fill_style(style, bounding_box):
     """Parse an XFL <FillStyle> element.
 
     Returns a tuple:
@@ -46,27 +52,31 @@ def parse_fill_style(style):
         attrib["fill"] = f"url(#{gradient.id})"
         extra_defs[gradient.id] = gradient.to_svg()
     elif style.tag.endswith("RadialGradient"):
-        # TODO: Support RadialGradient
-        warnings.warn("RadialGradient is not supported yet")
+        radius = get_radius(bounding_box)
+        gradient = RadialGradient.from_xfl(style, radius)
+        attrib["fill"] = f"url(#{gradient.id})"
+        extra_defs[gradient.id] = gradient.to_svg()
     else:
         warnings.warn(f"Unknown fill style: {xml_str(style)}")
 
     return attrib, extra_defs
 
 
-def parse_stroke_style(style):
+def parse_stroke_style(style, bounding_box):
     """Parse an XFL <StrokeStyle> element.
 
     Returns a dict of SVG style attributes.
     """
     if not style.tag.endswith("SolidStroke"):
         warnings.warn(f"Unknown stroke style: {xml_str(style)}")
-        return {"fill": "none"}
+        return {"fill": "none"}, {}
 
-    check_known_attrib(style, {"scaleMode", "weight", "joints", "miterLimit", "caps"})
+    check_known_attrib(
+        style, {"scaleMode", "weight", "joints", "miterLimit", "caps", "solidStyle"}
+    )
     if style.get("scaleMode") != "normal":
         warnings.warn(f"Unknown `scaleMode` value: {style.get('scaleMode')}")
-        return {"fill": "none"}
+        # return {"fill": "none"}, {}
 
     cap = style.get("caps", "round")
     if cap == "none":
@@ -78,17 +88,16 @@ def parse_stroke_style(style):
         "stroke-linejoin": style.get("joints", "round"),
         "fill": "none",
     }
+    extra_defs = {}
 
-    fill = style[0][0]
-    if fill.tag.endswith("RadialGradient"):
-        # TODO: Support RadialGradient
-        warnings.warn("RadialGradient is not supported yet")
-        return attrib
-    elif not fill.tag.endswith("SolidColor"):
-        warnings.warn(f"Unknown stroke fill: {xml_str(fill)}")
-        return attrib
+    solid = style.get("solidStyle")
+    if solid:
+        if solid != "hairline":
+            warnings.warn(f"Unknown `solidStyle` value: {style.get('solidStyle')}")
+        else:
+            # A hairline solidStyle overrides the 'weight' attribute.
+            attrib["stroke-width"] = "0.05"
 
-    update(attrib, ("stroke", "stroke-opacity"), parse_solid_color(fill))
     if attrib["stroke-linejoin"] == "miter":
         # If the XFL does not specify a miterLimit, Animate's SVG exporter will
         # set stroke-miterlimit to 3. This seems to match what Flash does [*].
@@ -98,4 +107,16 @@ def parse_stroke_style(style):
         # [*]: https://github.com/ruffle-rs/ruffle/blob/d3becd9/core/src/avm1/globals/movie_clip.rs#L283-L290
         attrib["stroke-miterlimit"] = style.get("miterLimit", "5")
 
-    return attrib
+    fill = style[0][0]
+    if fill.tag.endswith("RadialGradient"):
+        radius = get_radius(bounding_box)
+        gradient = RadialGradient.from_xfl(fill, radius)
+        attrib["stroke"] = f"url(#{gradient.id})"
+        extra_defs[gradient.id] = gradient.to_svg()
+    elif fill.tag.endswith("SolidColor"):
+        update(attrib, ("stroke", "stroke-opacity"), parse_solid_color(fill))
+    else:
+        warnings.warn(f"Unknown stroke fill: {xml_str(fill)}")
+        return attrib, extra_defs
+
+    return attrib, extra_defs

--- a/xfl2svg/svg_renderer.py
+++ b/xfl2svg/svg_renderer.py
@@ -314,7 +314,7 @@ class SvgRenderer:
         defs = {}
         body = []
 
-        fill_g, stroke_g, extra_defs = xfl_domshape_to_svg(domshape, inside_mask)
+        fill_g, stroke_g, extra_defs, _ = xfl_domshape_to_svg(domshape, inside_mask)
         defs.update(extra_defs)
 
         if fill_g is not None:

--- a/xfl2svg/util.py
+++ b/xfl2svg/util.py
@@ -23,6 +23,7 @@ def check_known_attrib(element, known):
             f"  Known keys:   {known}\n"
             f"  Unknown keys: {unknown}"
         )
+        raise Exception()
 
 
 def get_matrix(element):
@@ -47,3 +48,20 @@ def get_matrix(element):
         ]
 
     return IDENTITY_MATRIX
+
+
+def merge_bounding_boxes(original, addition):
+    """Return a bounding box containing both input boxes. Each input box should be a
+    sequence (minX, minY, maxX, maxY)."""
+    if addition == None:
+        return original
+
+    if original == None:
+        return addition
+
+    return (
+        min(original[0], addition[0]),
+        min(original[1], addition[1]),
+        max(original[2], addition[2]),
+        max(original[3], addition[3]),
+    )


### PR DESCRIPTION
This required a refactor since radial gradient styles require shape
information. The change:

- Attaches bounding box calculations for all point lists.
- Moves all SVG generation out of edge.py. edge.py now only calculates
path lists for shapes + bounding boxes.
- Changes the main shape.py loop to (1) gather fill and stroke ids, (2)
use edge.py to get the fill and stroke path lists, and lastly (3) generate the
SVG, including style information.